### PR TITLE
fix(editor): code content switching having problems that the old code remain in the editor after language switching. Now FIXED.

### DIFF
--- a/frontend/components/auth/forms/sign-up.tsx
+++ b/frontend/components/auth/forms/sign-up.tsx
@@ -188,7 +188,7 @@ export const SignUpForm = () => {
         return (
           <NRAForm
             name="sign-up-form"
-            className="px-0! w-full! overflow-hidden! "
+            className="px-0! w-full! "
           >
             <ProgressDotsStyle $theme={theme} />
 

--- a/frontend/components/auth/signin/index.tsx
+++ b/frontend/components/auth/signin/index.tsx
@@ -4,7 +4,7 @@ import RightSide from './right-side'
 
 const SignIn = () => {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2">
+    <div className="grid grid-cols-1 md:grid-cols-2 bg-black">
       <LeftSide/>
       <RightSide/>      
     </div>

--- a/frontend/components/auth/signup/index.tsx
+++ b/frontend/components/auth/signup/index.tsx
@@ -4,7 +4,7 @@ import RightSide from "./right-side";
 
 const SignUp = () => {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2">
+    <div className="grid grid-cols-1 md:grid-cols-2 bg-black">
       <LeftSide/>
       <RightSide/>      
     </div>

--- a/frontend/components/auth/signup/right-side.tsx
+++ b/frontend/components/auth/signup/right-side.tsx
@@ -12,7 +12,7 @@ const RightSide = () => {
   const { themeName } = useTheme();
   const theme = themeConfig(themeName);
   return (
-    <div className="flex flex-col h-svh items-center justify-center gap-y-5 px-6 max-[460px]:w-full w-[26rem] md:w-full lg:w-[26rem] place-self-center relative">
+    <div className="flex flex-col h-svh items-center justify-center gap-y-5 px-6 max-[460px]:w-full w-[26rem] md:w-full lg:w-[26rem] place-self-center relative overflow-hidden! ">
       <div className="mb-5 w-full flex items-center justify-between">
         <Logo />
         <span

--- a/frontend/components/editor/editor.tsx
+++ b/frontend/components/editor/editor.tsx
@@ -25,6 +25,7 @@ import { useDispatch } from "react-redux";
 import {
   selectedCode,
   selectedEditorId,
+  selectedLang,
   selectedOutput,
   setCodeRedux,
   setEditorId,
@@ -55,14 +56,14 @@ export default function EditorComponent({
   p_lang: string;
   isShared?: boolean;
 }) {
-  const defaultCode = getDefaultCode(p_lang);
+  // const defaultCode = getDefaultCode(p_lang);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [isCopied, setIsCopied] = useState(false);
-  const [sharingDetails, setSharingDetails] = useState(null);
+  const lang = useSelector(selectedLang);
+  // const [sharingDetails, setSharingDetails] = useState(null);
 
-  // Share
-  
+  // console.log("___Editor___ (defaultCode)", defaultCode)
 
   const currentCode = useSelector(selectedCode);
   const currentOutput = useSelector(selectedOutput);
@@ -107,14 +108,14 @@ export default function EditorComponent({
     autoSaveCode.mutate(
       {
         userId: userId,
-        lang: p_lang,
+        lang,
         code: debouncedCode,
       },
       {
         onSuccess: (res) => {
           lastSaveRef.current = debouncedCode;
-          dispatch(setCodeRedux(res?.code));
           dispatch(setLangRedux(res?.lang));
+          dispatch(setCodeRedux(res?.code));
           dispatch(setEditorId(res?.id));
           // isAutoSaving.current = false;
           toast.success(messagesConfig.AUTOSAVE.SUCCESS, { id: "autoSave" });
@@ -125,7 +126,7 @@ export default function EditorComponent({
         },
       }
     );
-  }, [isShared, debouncedCode, userId, p_lang, dispatch]);
+  }, [isShared, debouncedCode, userId, lang, dispatch]);
 
   useEffect(() => {
     setTimeout(() => {
@@ -183,8 +184,7 @@ export default function EditorComponent({
 
   // Generate Shared Link
 
-
-  console.log(sharingDetails)
+  // console.log(sharingDetails)
 
   return (
     <div
@@ -229,13 +229,16 @@ export default function EditorComponent({
               />
               <div className="pt-2">
                 <Editor
+                  key={lang}
                   value={currentCode}
-                  onChange={(value) => dispatch(setCodeRedux(value ?? ""))}
+                  onChange={(value) => {
+                    dispatch(setCodeRedux(value ?? ""));
+                  }}
                   width="100%"
                   height="calc(95vh - 95px)"
                   defaultLanguage={p_lang}
-                  language={p_lang}
-                  defaultValue={defaultCode}
+                  language={lang}
+                  // defaultValue={defaultCode}
                   theme="app-dark"
                   onMount={handleOnMount}
                   beforeMount={handleBeforeMount}
@@ -290,7 +293,7 @@ export default function EditorComponent({
             </div>
           </Splitter.Panel>
         </StyledSplitter>
-      </div>      
+      </div>
     </div>
   );
 }

--- a/frontend/components/editor/header.tsx
+++ b/frontend/components/editor/header.tsx
@@ -68,6 +68,9 @@ const EditorHeaderComponent = (props: HeaderProps) => {
     props.setLoading(true);
     props.setError("");
 
+    console.log(currentCode)
+    console.log(props.p_lang)
+
     try {
       const res = await runCode({
         code: currentCode,

--- a/frontend/components/editor/index.tsx
+++ b/frontend/components/editor/index.tsx
@@ -10,23 +10,38 @@ import {
 } from "@/redux/slices/editorSlice";
 import { selectedUserId } from "@/redux/slices/userSlice";
 import { useSelector } from "react-redux";
+import { getDefaultCode } from "@/helper/defaultCode";
 
 const MainEditor = ({ p_lang }: { p_lang: string }) => {
   const dispatch = useDispatch();
-  
+  const defaultCode = getDefaultCode(p_lang);
+
   const userId = useSelector(selectedUserId);
-  const { data: codeData } = useGetCode({
+  const { data: codeData, isLoading } = useGetCode({
     userId: userId,
     lang: p_lang,
   });
 
   useEffect(() => {
-    if (!codeData) return;
-    dispatch(setEditorId(codeData?.id));
-    dispatch(setCodeRedux(codeData?.code));
-    dispatch(setOutputRedux(codeData?.output));
-    dispatch(setLangRedux(codeData?.lang));
-  }, [codeData, dispatch]);
+    dispatch(setLangRedux(p_lang));
+  }, [p_lang, dispatch]);
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    if (!codeData) {
+      dispatch(setCodeRedux(defaultCode));
+      return;
+    }
+
+    if (codeData.lang === p_lang) {
+      dispatch(setCodeRedux(codeData.code));
+      dispatch(setEditorId(codeData.id));
+      dispatch(setOutputRedux(codeData.output));
+    }
+  }, [codeData, isLoading, p_lang, defaultCode, dispatch]);
+
+  if (isLoading) return <p>Loading ...</p>;
 
   return (
     <div>

--- a/frontend/components/editor/sider.tsx
+++ b/frontend/components/editor/sider.tsx
@@ -8,6 +8,8 @@ import { usePathname } from "next/navigation";
 import { useSelector } from "react-redux";
 import styled from "styled-components";
 import { appUrls } from "@/config/navigation.config";
+import { useDispatch } from "react-redux";
+import { setLangRedux } from "@/redux/slices/editorSlice";
 
 const StyledLink = styled(Link)<{ $theme: ThemeTypes; $isActive: boolean }>`
   &:hover {
@@ -16,9 +18,11 @@ const StyledLink = styled(Link)<{ $theme: ThemeTypes; $isActive: boolean }>`
   }
 `;
 
-const Sider = ({p_lang}: {p_lang: string}) => {
-  const editorTheme = useSelector(selectEditorTheme)
+const Sider = ({ p_lang }: { p_lang: string }) => {
+  const editorTheme = useSelector(selectEditorTheme);
   const theme = themeConfig(editorTheme);
+
+  const dispatch = useDispatch();
 
   const languageLogo = (lang: string) => {
     const uri = getDataUrls(lang);
@@ -63,6 +67,9 @@ const Sider = ({p_lang}: {p_lang: string}) => {
               backgroundColor:
                 p_lang === x.link ? theme.activeColor : theme.border10,
               borderColor: theme.border20,
+            }}
+            onClick={() => {
+              dispatch(setLangRedux(x.link));
             }}
           >
             {x.logo}

--- a/frontend/redux/slices/editorSlice.ts
+++ b/frontend/redux/slices/editorSlice.ts
@@ -1,44 +1,78 @@
-import { createSlice, PayloadAction } from "@reduxjs/toolkit"
-import { RootState } from "../store"
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { RootState } from "../store";
+
+export interface ILangContent {
+  code: string;
+  output: string;
+  editorId: string;
+}
 
 export interface IEditorState {
-    code: string,
-    lang: string,
-    output: string,
-    editorId: string,
+  content: Record<string, ILangContent>;
+  currentLang: string;
 }
 
 const initialState: IEditorState = {
-    code : "",
-    lang : "",
-    output : "",
-    editorId : "",
-}
+  content: {},
+  currentLang: "",
+};
 
 export const editorCodeSlice = createSlice({
-    name: "editorCode",
-    initialState,
-    reducers: {
-        setCodeRedux: (state, action: PayloadAction<string>) => {
-            state.code = action.payload
-        },
-        setLangRedux: (state, action: PayloadAction<string>) => {
-            state.lang = action.payload
-        },
-        setOutputRedux: (state, action: PayloadAction<string>) => {
-            state.output = action.payload
-        },
-        setEditorId: (state, action: PayloadAction<string>) => {
-            state.editorId = action.payload
-        },
-    }
-})
+  name: "editorCode",
+  initialState,
+  reducers: {
+    setLangRedux: (state, action: PayloadAction<string>) => {
+      state.currentLang = action.payload;
+      if (!state.content[action.payload]) {
+        state.content[action.payload] = {
+          code: "", 
+          output: "",
+          editorId: "",
+        };
+      }
+    },
 
-export const {setCodeRedux, setLangRedux, setOutputRedux, setEditorId} = editorCodeSlice.actions
+    setCodeRedux: (state, action: PayloadAction<string>) => {
+      const lang = state.currentLang;
+      if (!lang) return;
 
-export const selectedCode = (state: RootState) => state.editorCode.code
-export const selectedLang = (state: RootState) => state.editorCode.lang
-export const selectedOutput = (state: RootState) => state.editorCode.output
-export const selectedEditorId = (state: RootState) => state.editorCode.editorId
+      state.content[lang].code = action.payload;
+    },
 
-export default editorCodeSlice.reducer
+    setOutputRedux: (state, action: PayloadAction<string>) => {
+      const lang = state.currentLang;
+      if (!lang) return;
+
+      state.content[lang].output = action.payload;
+    },
+
+    setEditorId: (state, action: PayloadAction<string>) => {
+      const lang = state.currentLang;
+      if (!lang) return;
+
+      state.content[lang].editorId = action.payload;
+    },
+  },
+});
+
+export const { setCodeRedux, setLangRedux, setOutputRedux, setEditorId } =
+  editorCodeSlice.actions;
+
+export const selectedLang = (state: RootState) => state.editorCode.currentLang;
+
+export const selectedCode = (state: RootState) => {
+  const lang = state.editorCode.currentLang;
+  return state.editorCode.content[lang]?.code || "";
+};
+
+export const selectedOutput = (state: RootState) => {
+  const lang = state.editorCode.currentLang;
+  return state.editorCode.content[lang]?.output || "";
+};
+
+export const selectedEditorId = (state: RootState) => {
+  const lang = state.editorCode.currentLang;
+  return state.editorCode.content[lang]?.editorId || "";
+};
+
+export default editorCodeSlice.reducer;

--- a/frontend/redux/store.ts
+++ b/frontend/redux/store.ts
@@ -16,9 +16,16 @@ const persistUserConfig = {
   storage
 }
 
+// const persistEditorConfig_temp = {
+//   key: "editor",
+//   storage
+// }
+
 const persistedPreference = persistReducer(persistPreferenceConfig, preferencesReducer)
 
 const persistedUserDetails = persistReducer(persistUserConfig, userReducer)
+
+// const persistedEditor_temp =  persistReducer(persistEditorConfig_temp, editorCodeReducer)
 
 export const store = configureStore({
     reducer: {


### PR DESCRIPTION
FIXED BELOW ISSUE
- Old code keeps showing even after switching to a different language.
- Editor doesn't update code when the language changes.
- Previous language's code stays visible after switching languages.
- Language switch works, but the editor still shows old code.