### PR TITLE
fix(issue: 33): shared content mixing up with regular content because of redux. #33

### DIFF
--- a/frontend/components/editor/sharedEditor.tsx
+++ b/frontend/components/editor/sharedEditor.tsx
@@ -1,0 +1,234 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { Splitter } from "antd";
+import styled from "styled-components";
+import { themeConfig } from "@/config/themeConfig";
+import { Editor, Monaco } from "@monaco-editor/react";
+import { useSelector } from "react-redux";
+import {
+  selectEditorFont,
+  selectEditorFontSize,
+  selectEditorTheme,
+  selectWebsiteFont,
+} from "@/redux/slices/preferenceSlice";
+import { editorFonts, websiteFonts } from "@/fonts";
+import getEditorSytaxRules from "@/helper/editor-syntax-rules";
+import { ThemeTypes } from "@/@types/theme";
+import { EditorFontKey, WebsiteFontsKey } from "@/@types/font";
+import { useDispatch } from "react-redux";
+import { LuLoader } from "react-icons/lu";
+import { selectedSharedCode, selectedSharedLang, selectedSharedOutput, setShareCodeRedux } from "@/redux/slices/sharedEditorSlice";
+import SharedEditorHeaderComponent from "./sharedHeader";
+
+const StyledSplitter = styled(Splitter)<{ $theme: ThemeTypes }>`
+  .ant-splitter-bar {
+    background: ${({ $theme }) => $theme.splitterColor} !important;
+    width: 4px !important;
+  }
+
+  .ant-splitter-bar-dragger::before {
+    background: ${({ $theme }) => $theme.splitterColor} !important;
+  }
+`;
+
+export default function SharedEditorComponent({
+  p_lang,
+  isShared = false,
+}: {
+  p_lang: string;
+  isShared?: boolean;
+}) {
+  // const defaultCode = getDefaultCode(p_lang);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [isCopied, setIsCopied] = useState(false);
+  const lang = useSelector(selectedSharedLang);
+  // const [sharingDetails, setSharingDetails] = useState(null);
+
+  // console.log("___Editor___ (defaultCode)", defaultCode)
+
+  const currentCode = useSelector(selectedSharedCode);
+  const currentOutput = useSelector(selectedSharedOutput);
+
+  // console.log("currentCode", currentCode);
+
+  const dispatch = useDispatch();
+
+  const editorFont = useSelector(selectEditorFont);
+  const editorFontSize = useSelector(selectEditorFontSize);
+  const editorTheme = useSelector(selectEditorTheme);
+  const websiteFont = useSelector(selectWebsiteFont);
+
+  const theme = themeConfig(editorTheme);
+
+  // refs for monaco editor
+  const editorRef = useRef<any>(null);
+  const monacoRef = useRef<any>(null);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setIsCopied(false);
+    }, 1000);
+  }, [isCopied]);
+
+  const syntaxRules = getEditorSytaxRules(theme);
+
+  const handleBeforeMount = (monaco: Monaco) => {
+    monaco.editor.defineTheme("app-dark", {
+      base: "vs-dark",
+      inherit: true,
+      rules: syntaxRules,
+      colors: {
+        "editor.background": theme.editorBackground,
+        "editor.foreground": theme.outputColor,
+        "editorLineNumber.foreground": theme.editorLineNumberForeground,
+        "editorLineNumber.activeForeground": theme.outputColor,
+        "editor.selectionBackground": theme.editorSelectionBackground,
+        "editorCursor.foreground": theme.outputColor,
+      },
+    });
+  };
+
+  const handleOnMount = (editor: any, monaco: any) => {
+    editorRef.current = editor;
+    monacoRef.current = monaco;
+    monaco.editor.setTheme("app-dark");
+  };
+
+  useEffect(() => {
+    if (monacoRef.current && editorRef.current) {
+      const newTheme = themeConfig(editorTheme);
+      const newSyntaxRules = getEditorSytaxRules(newTheme);
+
+      // redefing the theme with new colors
+      monacoRef.current.editor.defineTheme("app-dark", {
+        base: "vs-dark",
+        inherit: true,
+        rules: newSyntaxRules,
+        colors: {
+          "editor.background": newTheme.editorBackground,
+          "editor.foreground": newTheme.outputColor,
+          "editorLineNumber.foreground": newTheme.editorLineNumberForeground,
+          "editorLineNumber.activeForeground": newTheme.outputColor,
+          "editor.selectionBackground": newTheme.editorSelectionBackground,
+          "editorCursor.foreground": newTheme.outputColor,
+        },
+      });
+
+      monacoRef.current.editor.setTheme("app-dark");
+    }
+  }, [editorTheme]);
+
+  // Generate Shared Link
+
+  // console.log(sharingDetails)
+
+  return (
+    <div
+      style={{
+        fontFamily: "Inter, Roboto, system-ui",
+        height: "calc(100vh - 25px)",
+      }}
+      className="w-full overflow-y-hidden flex items-start justify-between gap-x-0 relative"
+    >
+      <div className="flex w-full overflow-hidden border-t border-t-white/20">
+        <StyledSplitter
+          $theme={theme}
+          style={{
+            height: "100%",
+            boxShadow: "0 0 10px rgba(0, 0, 0, 0.1)",
+            width: "100%",
+          }}
+        >
+          <Splitter.Panel defaultSize="60%" min="40%">
+            <div
+              style={{
+                marginBottom: 8,
+                borderColor: theme?.border20,
+                background: theme.editorBackground,
+              }}
+              className={`border border-t-0 border-r-0 overflow-hidden text-white ${
+                websiteFonts[websiteFont as WebsiteFontsKey]?.className
+              }`}
+            >
+              <SharedEditorHeaderComponent
+                editorTheme={editorTheme}
+                isOutput={false}
+                p_lang={p_lang}
+                isCopied={isCopied}
+                setIsCopied={setIsCopied}
+                loading={loading}
+                setLoading={setLoading}
+                setError={setError}
+                isShared={isShared}
+              />
+              <div className="pt-2">
+                <Editor
+                  key={lang}
+                  value={currentCode}
+                  onChange={(value) => {
+                    dispatch(setShareCodeRedux(value ?? ""));
+                  }}
+                  width="100%"
+                  height="calc(95vh - 95px)"
+                  defaultLanguage={p_lang}
+                  language={lang}
+                  // defaultValue={defaultCode}
+                  theme="app-dark"
+                  onMount={handleOnMount}
+                  beforeMount={handleBeforeMount}
+                  options={{
+                    fontFamily: editorFonts[editorFont as EditorFontKey],
+                    fontSize: editorFontSize,
+                    minimap: { enabled: false },
+                    automaticLayout: true,
+                  }}
+                />
+              </div>
+            </div>
+          </Splitter.Panel>
+          <Splitter.Panel defaultSize="40%" min="20%">
+            <div
+              className={`min-h-[95vh] overflow-y-auto border-r relative ${
+                websiteFonts[websiteFont as WebsiteFontsKey]?.className
+              }`}
+              style={{
+                background: theme.outputBackground,
+                color: theme.outputColor,
+                borderColor: theme.border15,
+                whiteSpace: "pre-wrap",
+              }}
+            >
+              <SharedEditorHeaderComponent
+                editorTheme={editorTheme}
+                isOutput={true}
+                loading={loading}
+                setError={setError}
+              />
+              <div className="p-2 ">
+                {error ? (
+                  <span style={{ color: "#ffb4b4" }}>{error}</span>
+                ) : (
+                  currentOutput ||
+                  (loading ? (
+                    <div
+                      className="absolute top-0 left-0 w-full h-full flex items-center justify-center backdrop-blur-[2px]"
+                      style={{
+                        backgroundColor: theme.border10,
+                        color: theme.textColor,
+                      }}
+                    >
+                      <LuLoader className="animate-spin" size={24} />
+                    </div>
+                  ) : (
+                    <p className="opacity-60">No output</p>
+                  ))
+                )}
+              </div>
+            </div>
+          </Splitter.Panel>
+        </StyledSplitter>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/editor/sharedHeader.tsx
+++ b/frontend/components/editor/sharedHeader.tsx
@@ -1,0 +1,122 @@
+
+import { themeConfig } from "@/config/themeConfig";
+import { CopyButton, RunButton, TransparentButton } from "./header-buttons";
+import { useRunCode, useUpdateOutput } from "@/services/code";
+import { useSelector } from "react-redux";
+import { HeaderProps } from "@/@types";
+import { useDispatch } from "react-redux";
+import { useRef, useState } from "react";
+import { IoMdShare } from "react-icons/io";
+import { AButton } from "../ui/antd";
+import { cn } from "@/lib/utils";
+import { selectedSharedCode, selectedSharedEditorId, setShareOutputRedux } from "@/redux/slices/sharedEditorSlice";
+
+const SharedEditorHeaderComponent = (props: HeaderProps) => {
+  const dispatch = useDispatch();
+
+  const [open, setOpen] = useState(false);
+  const currentCode = useSelector(selectedSharedCode);
+
+  // console.log("Curr Code", currentCode);
+
+  const theme = themeConfig(props.editorTheme);
+
+  const { mutateAsync: runCode } = useRunCode();
+  const { mutateAsync: updateOutput } = useUpdateOutput();
+
+  const editorId = useSelector(selectedSharedEditorId);
+  const lastOpt = useRef("");
+
+  // console.log(editorId)
+
+  // Ouput Header
+  if (props.isOutput) {
+    return (
+      <div
+        className="flex items-center justify-between gap-8 text-xs bg-[#43434354] border-b  px-2 py-1.5 h-[50px]"
+        style={{
+          borderBottomColor: `${theme?.border10}`,
+        }}
+      >
+        <span className="text-base font-semibold tracking-[1.2px] ">
+          Output
+        </span>
+        <TransparentButton onClick={clearOutput} loading={props.loading} />
+      </div>
+    );
+  }
+
+  const handleRunCode = async () => {
+    props.setLoading(true);
+    props.setError("");
+
+    console.log(currentCode);
+    console.log(props.p_lang);
+
+    try {
+      const res = await runCode({
+        code: currentCode,
+        lang: props.p_lang,
+      });
+      // console.log(res);
+      const output = res.output ?? "";
+      if (lastOpt.current !== output) {
+        updateOutput(
+          { editorId, output },
+          {
+            onSuccess: (res) => {
+              // console.log("Updated", res);
+              lastOpt.current = output;
+              dispatch(setShareOutputRedux(output));
+            },
+          }
+        );
+      }
+    } catch (err: any) {
+      props.setError(err.message ?? String(err));
+    } finally {
+      props.setLoading(false);
+    }
+  };
+
+  function clearOutput() {
+    props.setError("");
+    dispatch(setShareOutputRedux(""));
+  }
+
+  const copyCode = () => {
+    navigator.clipboard.writeText(currentCode).then(() => {
+      props.setIsCopied(true);
+    });
+  };
+
+  return (
+    // Editor Header
+    <div className="flex items-center justify-between text-base h-[50px] relative w-full">
+      <span className="font-medium text-center flex items-center justify-center gap-x-2 w-[100px]">
+        main.py
+        {/* <IoMdCloudDone className="opacity-40 size-3.5" /> */}
+      </span>
+
+      <div
+        className="flex-1/2 flex items-center justify-end gap-2 px-2 py-1.5 h-full rounded-bl-xl border-b border-l "
+        style={{
+          background: theme.headerColor,
+          borderBottomColor: theme?.border10,
+          borderLeft: theme?.border10,
+        }}
+      >
+        {/* <TransparentButton
+          onClick={() => {
+            dispatch(setCodeRedux(""));
+          }}
+        /> */}
+
+        <CopyButton onClick={copyCode} isCopied={props.isCopied} />
+        <RunButton onClick={handleRunCode} loading={props.loading} />
+      </div>
+    </div>
+  );
+};
+
+export default SharedEditorHeaderComponent;

--- a/frontend/components/editor/template.tsx
+++ b/frontend/components/editor/template.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const EditorTemplate = () => {
+  return (
+    <div>EditorTemplate</div>
+  )
+}
+
+export default EditorTemplate

--- a/frontend/components/share/ShareEditor.tsx
+++ b/frontend/components/share/ShareEditor.tsx
@@ -13,6 +13,7 @@ import { WebsiteFontsKey } from "@/@types/font";
 import { themeConfig } from "@/config/themeConfig";
 import { cn } from "@/lib/utils";
 import { FaInfoCircle } from "react-icons/fa";
+import SharedEditorComponent from "../editor/sharedEditor";
 
 export const OWNER_WIDTH = "25rem";
 
@@ -44,7 +45,7 @@ const ShareEditor = ({
 
   return (
     <div className="w-full flex gap-x-2">
-      <EditorComponent p_lang={sharedData?.lang?.trim() || lang} isShared />
+      <SharedEditorComponent p_lang={sharedData?.lang?.trim() || lang} isShared />
       <div
         className=" text-wrap text-white overflow-x-hidden overflow-y-auto pb-4 custom-scrollbar"
         style={{

--- a/frontend/components/share/by-me/index.tsx
+++ b/frontend/components/share/by-me/index.tsx
@@ -1,11 +1,6 @@
 "use client";
 import { IUserDetails } from "@/@types/auth";
-import { IOwnerDetails, IShareByMeResRemaining, IShareDataModel } from "@/@types/share";
-import {
-  setCodeRedux,
-  setLangRedux,
-  setOutputRedux,
-} from "@/redux/slices/editorSlice";
+import { IShareByMeResRemaining, IShareDataModel } from "@/@types/share";
 import { selectedUserId } from "@/redux/slices/userSlice";
 import { useSharedByMeDataDetails } from "@/services/share";
 import { useParams } from "next/navigation";
@@ -14,6 +9,7 @@ import { useDispatch } from "react-redux";
 import { useSelector } from "react-redux";
 import ShareEditor from "../ShareEditor";
 import Users from "../users";
+import { setShareCodeRedux, setShareIdRedux, setShareLangRedux, setShareOutputRedux } from "@/redux/slices/sharedEditorSlice";
 
 const SharedByMePage = () => {
   const params = useParams();
@@ -35,14 +31,14 @@ const SharedByMePage = () => {
   const { data: sharedData, isLoading } = useSharedByMeDataDetails(payload);
 
   // console.log("BY_ME", sharedData);
-
   // const otherShares = sharedData.
 
   useEffect(() => {
     if (!sharedData || isLoading) return;
-    dispatch(setLangRedux(sharedData?.share?.lang));
-    dispatch(setCodeRedux(sharedData?.share?.code));
-    dispatch(setOutputRedux(sharedData?.share?.output));
+    dispatch(setShareIdRedux(sharedData?.share.sharedId))
+    dispatch(setShareLangRedux(sharedData?.share?.lang));
+    dispatch(setShareCodeRedux(sharedData?.share?.code));
+    dispatch(setShareOutputRedux(sharedData?.share?.output));
 
     sharedWithRef.current = sharedData?.sharedWith;
     remainingRef.current = sharedData?.remaining;

--- a/frontend/components/share/owner.tsx
+++ b/frontend/components/share/owner.tsx
@@ -213,11 +213,11 @@ const Owner = ({ ownerDetails, remaining }: OwnerProps) => {
             {remaining?.map((rem, i) => (
               <Remaining
                 key={i}
-                code={rem.code}
-                lang={rem.lang}
+                code={rem?.code}
+                lang={rem?.lang}
                 sharedBy={ownerDetails}
-                sharedId={rem.sharedId}
-                createdAt={dateISOtoNormal(rem.createdAt)}
+                sharedId={rem?.sharedId}
+                createdAt={dateISOtoNormal(rem?.createdAt)}
               />
             ))}
           </div>

--- a/frontend/components/share/users.tsx
+++ b/frontend/components/share/users.tsx
@@ -67,11 +67,11 @@ const Users = ({
       {remaining?.map((rem, i) => (
         <Remaining
           key={i}
-          code={rem.share.code}
-          lang={rem.share.lang}
-          sharedWith={rem.sharedWith}
-          sharedId={rem.share.sharedId}
-          createdAt={dateISOtoNormal(rem.share.createdAt)}
+          code={rem?.share?.code}
+          lang={rem?.share?.lang}
+          sharedWith={rem?.sharedWith}
+          sharedId={rem?.share?.sharedId}
+          createdAt={dateISOtoNormal(rem?.share?.createdAt)}
         />
       ))}
     </div>

--- a/frontend/components/share/with-me/index.tsx
+++ b/frontend/components/share/with-me/index.tsx
@@ -1,10 +1,5 @@
 "use client";
 import { IOwnerDetails, IShareDataModel } from "@/@types/share";
-import {
-  setCodeRedux,
-  setLangRedux,
-  setOutputRedux,
-} from "@/redux/slices/editorSlice";
 import { selectedUserId } from "@/redux/slices/userSlice";
 import { useSharedWithMeDataDetails } from "@/services/share";
 import { useParams } from "next/navigation";
@@ -13,12 +8,14 @@ import { useDispatch } from "react-redux";
 import { useSelector } from "react-redux";
 import Owner from "../owner";
 import ShareEditor from "../ShareEditor";
+import { selectedSharedCode, setShareCodeRedux, setShareIdRedux, setShareLangRedux, setShareOutputRedux } from "@/redux/slices/sharedEditorSlice";
 
 const SharedWithMePage = () => {
   const params = useParams();
   const dispatch = useDispatch();
 
   const userId = useSelector(selectedUserId);
+  const currCode = useSelector(selectedSharedCode)
   const shareId = params?.editorId;
 
   const [ownerDetails, setOwnerDetails] = useState<IOwnerDetails>();
@@ -33,13 +30,17 @@ const SharedWithMePage = () => {
 
   const { data: sharedData, isLoading } = useSharedWithMeDataDetails(payload);
 
-  // console.log(sharedData);
+  console.log(sharedData);
+  
 
   useEffect(() => {
     if (!sharedData || isLoading) return;
-    dispatch(setLangRedux(sharedData?.share?.lang));
-    dispatch(setCodeRedux(sharedData?.share?.code));
-    dispatch(setOutputRedux(sharedData?.share?.output));
+    dispatch(setShareIdRedux(sharedData?.share.sharedId))
+    dispatch(setShareLangRedux(sharedData?.share?.lang));
+    dispatch(setShareCodeRedux(sharedData?.share?.code));
+    dispatch(setShareOutputRedux(sharedData?.share?.output));
+
+    console.log(currCode);
 
     ownerDetailsRef.current = sharedData?.share?.ownerDetails;
     remainingRef.current = sharedData?.remaining;

--- a/frontend/redux/slices/editorSlice.ts
+++ b/frontend/redux/slices/editorSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { RootState } from "../store";
+import { string } from "zod";
 
 export interface ILangContent {
   code: string;
@@ -57,6 +58,7 @@ export const editorCodeSlice = createSlice({
 
 export const { setCodeRedux, setLangRedux, setOutputRedux, setEditorId } =
   editorCodeSlice.actions;
+
 
 export const selectedLang = (state: RootState) => state.editorCode.currentLang;
 

--- a/frontend/redux/slices/sharedEditorSlice.ts
+++ b/frontend/redux/slices/sharedEditorSlice.ts
@@ -1,0 +1,89 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { ILangContent } from "./editorSlice";
+import { RootState } from "../store";
+
+export interface ISharedContent extends ILangContent {
+  lang: string
+}
+
+export interface ISharedEditorState {
+  content: Record<string, ISharedContent>;
+  sharedId: string
+}
+
+const initialState: ISharedEditorState = {
+  content: {},
+  sharedId: "",
+}
+
+export const sharedEditorCodeSlice = createSlice({
+  name: "sharedEditorCode",
+  initialState,
+  reducers: {
+    setShareIdRedux: (state, action: PayloadAction<string>) => {
+      state.sharedId = action.payload;
+      if (!state.content[action.payload]) {
+        state.content[action.payload] = {
+          code: "", 
+          output: "",
+          editorId: "",
+          lang: ""
+        };
+      }
+    },
+
+    setShareCodeRedux: (state, action: PayloadAction<string>) => {
+      const sharedId = state.sharedId;
+      if (!sharedId) return;
+
+      state.content[sharedId].code = action.payload;
+    },
+
+    setShareOutputRedux: (state, action: PayloadAction<string>) => {
+      const sharedId = state.sharedId;
+      if (!sharedId) return;
+
+      state.content[sharedId].output = action.payload;
+    },
+
+    setShareEditorId: (state, action: PayloadAction<string>) => {
+      const sharedId = state.sharedId;
+      if (!sharedId) return;
+
+      state.content[sharedId].editorId = action.payload;
+    },
+
+    setShareLangRedux: (state, action: PayloadAction<string>) => {
+      const sharedId = state.sharedId;
+      if (!sharedId) return;
+
+      state.content[sharedId].lang = action.payload;
+    },
+  },
+});
+
+export const {setShareCodeRedux, setShareEditorId, setShareIdRedux, setShareLangRedux, setShareOutputRedux} = sharedEditorCodeSlice.actions
+
+export const selectedSharedId = (state: RootState) => state.sharedEditorCode.sharedId;
+
+export const selectedSharedCode = (state: RootState) => {
+  const sharedId = state.sharedEditorCode.sharedId;
+  return state.sharedEditorCode.content[sharedId]?.code || "";
+};
+
+export const selectedSharedOutput = (state: RootState) => {
+  const sharedId = state.sharedEditorCode.sharedId;
+  return state.sharedEditorCode.content[sharedId]?.output || "";
+};
+
+export const selectedSharedEditorId = (state: RootState) => {
+  const sharedId = state.sharedEditorCode.sharedId;
+  return state.sharedEditorCode.content[sharedId]?.editorId || "";
+};
+
+export const selectedSharedLang = (state: RootState) => {
+  const sharedId = state.sharedEditorCode.sharedId;
+  return state.sharedEditorCode.content[sharedId]?.lang || "";
+};
+
+export default sharedEditorCodeSlice.reducer;

--- a/frontend/redux/store.ts
+++ b/frontend/redux/store.ts
@@ -5,7 +5,8 @@ import storage from "redux-persist/lib/storage";
 import { configureStore } from "@reduxjs/toolkit";
 import userReducer from "./slices/userSlice";
 import editorCodeReducer from "./slices/editorSlice";
-import activeTabReducer from "./slices/activeTab"
+import activeTabReducer from "./slices/activeTab";
+import sharedEditorCodeReducer from "./slices/sharedEditorSlice";
 
 const persistPreferenceConfig = {
   key: "preference",
@@ -44,6 +45,7 @@ export const store = configureStore({
     activeField: activeFieldReducer,
     user: persistedUserDetails,
     editorCode: editorCodeReducer,
+    sharedEditorCode: sharedEditorCodeReducer,
     activeTab: persistedActiveTab,
   },
   middleware: (getDefaultMiddleware) =>


### PR DESCRIPTION

- two different redux states have been created (`editorState`, `sharedEditorState`)
- `sharedEditorState` is for the shared one and obviously `editorState` for the normal one
- but also instead optimizing the editor, here I create 2 completely separate Editors for those two. It may seem as not a good choice as it can be optimised by creating a template or another component with props but to reduce the difficulty atleast for now two separeate editor components and editor header is introduced `SharedEditorComponent` and `SharedEditorHeaderComponent`. Previous `EditorComponent` and `EditorHeaderComponent` is untouched.

_Note: `SharedEditorComponent` and `SharedEditorHeaderComponent` are nothing but the copy-paste version or old `EditorComponent` and `EditorHeaderComponent` with just **sharedEditorState** in used._